### PR TITLE
fix: favicon

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,7 +6,7 @@ export default function Document() {
         <Html>
             <Head>
                 {/* Favicon  */}
-                <link rel="icon" type="icon" href="/assets/images/favicon.png" />
+                <link rel="icon" type="icon" href="/favicon.ico" />
                 {/* Fonts  */}
                 <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@400;500;700;800&display=swap" rel="stylesheet" />
             </Head>


### PR DESCRIPTION
**Link of notion**
https://www.notion.so/thegrind-app/Home-page-change-google-search-icon-and-company-icon-5c5cc0a27ecd418ab07136e2c496612d?pvs=4


changes:
the **relative pathway is wrong**,
change from 
/assets/images/favicon.png 
to
/favicon.ico
